### PR TITLE
Fix: Correct JavaScript and image paths on board page

### DIFF
--- a/board.html
+++ b/board.html
@@ -120,28 +120,28 @@
                 {
                     name: "Lawrence Kincheloe",
                     title: "President",
-                    bio: "Hi, I'm Lawrence Kincheloe. By day, I'm a systems engineer who gets to solve complex puzzles with wires, sensors, and code. But my real passion has always been tinkering, inventing, and—most importantly—sharing that excitement with others.
+                    bio: `Hi, I'm Lawrence Kincheloe. By day, I'm a systems engineer who gets to solve complex puzzles with wires, sensors, and code. But my real passion has always been tinkering, inventing, and—most importantly—sharing that excitement with others.
 
-That's why I founded the Idea Forge Foundation. Having been part of Oklahoma's DIY and maker scene for over a decade, I've seen firsthand what happens when curious people have the tools and support to bring their ideas to life. My goal is to use my professional experience to build a foundation that empowers our entire community to learn, create, and innovate. Let's build something cool together.",
-                    imageUrl: "images/lawrence.jpg" // Example: "images/aria_jenkins.jpg"
+That's why I founded the Idea Forge Foundation. Having been part of Oklahoma's DIY and maker scene for over a decade, I've seen firsthand what happens when curious people have the tools and support to bring their ideas to life. My goal is to use my professional experience to build a foundation that empowers our entire community to learn, create, and innovate. Let's build something cool together.`,
+                    imageUrl: "images/Lawrence.jpg" // Example: "images/aria_jenkins.jpg"
                 },
                 {
                     name: "Marcus Steiner",
                     title: "Vice Chair & Treasurer",
-                    bio: "Marcus Steiner is a nonprofit executive with extensive experience in program and education development, specializing in philanthropy and organizational strategy. He has spent years working with community foundations, private foundations, and high-net-worth individuals (HNWI) to drive impactful, mission-driven initiatives. Marcus holds a Master of Arts in History from Arizona State University and a Bachelor of Science in Business Administration from Indiana State University.
+                    bio: `Marcus Steiner is a nonprofit executive with extensive experience in program and education development, specializing in philanthropy and organizational strategy. He has spent years working with community foundations, private foundations, and high-net-worth individuals (HNWI) to drive impactful, mission-driven initiatives. Marcus holds a Master of Arts in History from Arizona State University and a Bachelor of Science in Business Administration from Indiana State University.
 
 As the owner of Dragonfly Consulting Group, Marcus partners with nonprofit organizations and philanthropic foundations to enhance their operations, optimize grantmaking, and create sustainable programs. His consulting expertise spans across strategic planning, program development, and human rights advocacy, helping organizations maximize their impact and build lasting social change.
 
 In addition to his work at Dragonfly, Marcus serves as the Chief Financial Officer at Patchwork Indy, where he leads financial strategy and supports workforce development and educational initiatives for immigrant and refugee communities in Indianapolis. He also teaches at SUNY Empire State University in its School for Graduate Studies.
 
-Marcus also led the Crane Center for Mass Atrocity Prevention, where he built a global network of 175,000 advocates and worked with U.S. lawmakers and international NGOs on key human rights issues. He coauthored the Holocaust and Mass Atrocity Prevention Open Educational Resource and has presented his work at institutions such as Columbia University and Notre Dame University.",
+Marcus also led the Crane Center for Mass Atrocity Prevention, where he built a global network of 175,000 advocates and worked with U.S. lawmakers and international NGOs on key human rights issues. He coauthored the Holocaust and Mass Atrocity Prevention Open Educational Resource and has presented his work at institutions such as Columbia University and Notre Dame University.`,
                     imageUrl: "images/marcus.jpg" // Example: "images/ben_carter.jpg"
                 },
                 {
                     name: "Derek Hubbard",
                     title: "Secretary",
-                    bio: "Hey, I'm Derek Hubbard. I'm a maker of things, drinker of coffee, and cracker of wise, living in Oklahoma City. I spend my days building with code and my nights... probably drinking more coffee. I love tackling a good challenge and believe a little humor makes everything run smoother.",
-                    imageUrl: "images/derek.jpg" // Example: "images/chloe_rodriguez.jpg"
+                    bio: `Hey, I'm Derek Hubbard. I'm a maker of things, drinker of coffee, and cracker of wise, living in Oklahoma City. I spend my days building with code and my nights... probably drinking more coffee. I love tackling a good challenge and believe a little humor makes everything run smoother.`,
+                    imageUrl: "images/Derek.jpg" // Example: "images/chloe_rodriguez.jpg"
                 },
                 {
                     name: "Peter Shryock",
@@ -156,7 +156,7 @@ Peter serves as a board member of the Idea Forge Foundation (501(c)(3)), a nonpr
 His technical background spans CAD/CAM, CNC programming, fabrication, robotics, and AI/ML development. He is currently studying digital twin robotics via Unity, ROS, and ML-Agents, with a focus on sim-to-real training and application. Much of his work is directed toward developing sustainable solutions for modern challenges, from renewable energy systems to eco-integrated architecture.
 
 Through his projects and leadership, Peter aims to lower barriers of entry for innovators, accelerate start-ups rooted in mentorship and community, and help design a future where technology, sustainability, and humanity move forward together. `,
-                    imageUrl: "images/peter.jpg" // Example: "images/david_maxwell.jpg"
+                    imageUrl: "images/Peter.jpg" // Example: "images/david_maxwell.jpg"
           
           
 


### PR DESCRIPTION
This commit fixes two issues on the board page:

1.  A JavaScript syntax error caused by using double quotes for multi-line strings in the `boardMembers` array. This was fixed by replacing the double quotes with backticks (template literals).
2.  Incorrect image paths for several board members due to case-sensitivity issues. The filenames in the `imageUrl` properties have been corrected to match the actual filenames in the `images/` directory.

These changes resolve the issue where board member profiles were not displaying correctly.