### PR TITLE
Fix broken Stripe payment links on membership page

### DIFF
--- a/membership.html
+++ b/membership.html
@@ -202,7 +202,7 @@
                                 <span class="text-gray-500">/mo</span>
                             </div>
                             <p class="text-gray-600 mb-8 flex-grow">Support the "Maker Passport" & Innovation in our community.</p>
-                            <a href="https://buy.stripe.com/afa00jgsdeuo4diaBGcbC02" target="_blank" rel="noopener noreferrer" class="block w-full text-center bg-gray-800 text-white font-semibold px-4 py-3 rounded-lg hover:bg-gray-900 transition-colors">
+                            <a href="https://buy.stripe.com/aFa00jgsdeuo4diaBGcbC02" target="_blank" rel="noopener noreferrer" class="block w-full text-center bg-gray-800 text-white font-semibold px-4 py-3 rounded-lg hover:bg-gray-900 transition-colors">
                                 Support Us
                             </a>
                         </div>
@@ -230,7 +230,7 @@
                                     <span>Thu, Fri, Sat from 4pm to 9pm</span>
                                 </li>
                             </ul>
-                            <a href="https://buy.stripe.com/dRm8wP4Jvcmg1169xcCbC01" target="_blank" rel="noopener noreferrer" class="block w-full text-center bg-orange-500 text-white font-semibold px-4 py-3 rounded-lg hover:bg-orange-600 transition-colors cta-button">
+                            <a href="https://buy.stripe.com/dRm8wP4Jvcmg1169xCcbC01" target="_blank" rel="noopener noreferrer" class="block w-full text-center bg-orange-500 text-white font-semibold px-4 py-3 rounded-lg hover:bg-orange-600 transition-colors cta-button">
                                 Sign Up Now
                             </a>
                         </div>
@@ -245,7 +245,7 @@
                                 <span class="text-4xl font-extrabold text-gray-900">$200</span>
                             </div>
                             <p class="text-gray-600 mb-8 flex-grow">Fully fund one month for a community member who needs financial assistance.</p>
-                            <a href="https://buy.stripe.com/dRm28rgsdcMg4dicOCbc03" target="_blank" rel="noopener noreferrer" class="block w-full text-center bg-teal-600 text-white font-semibold px-4 py-3 rounded-lg hover:bg-teal-700 transition-colors">
+                            <a href="https://buy.stripe.com/dRm28rgsdcmg4dicJOcbC03" target="_blank" rel="noopener noreferrer" class="block w-full text-center bg-teal-600 text-white font-semibold px-4 py-3 rounded-lg hover:bg-teal-700 transition-colors">
                                 Donate
                             </a>
                         </div>


### PR DESCRIPTION
The Stripe checkout buttons on the membership page were directing users to invalid URLs that threw 404 errors. This was caused by missing or incorrectly cased characters in the link IDs (e.g. `c03` vs `C03` or `OC` vs `0C`). 

This PR corrects the `href` URLs in `membership.html` using the validated and confirmed active Stripe links provided. Verified via Playwright automation.

---
*PR created automatically by Jules for task [18052565283090321183](https://jules.google.com/task/18052565283090321183) started by @LokiMetaSmith*