### PR TITLE
Update "Join the Lab" button to mailto link

### DIFF
--- a/oil.html
+++ b/oil.html
@@ -102,7 +102,7 @@
                     A collaborative, standing program dedicated to open-source hardware and community-driven tech projects.
                 </p>
                 <div class="flex justify-center space-x-4">
-                    <a href="membership.html" class="bg-orange-500 text-white font-semibold px-8 py-3 rounded-lg cta-button hover:bg-orange-600">
+                    <a href="mailto:foundation@idea-forge.org?subject=Interest%20in%20joining%20the%20OIL%20initiative&body=Hi%2C%20I%20am%20interested%20in%20joining%20the%20Open%20Innovation%20Lab%20(OIL)%20initiative.%20Please%20let%20me%20know%20what%20the%20next%20steps%20are." class="bg-orange-500 text-white font-semibold px-8 py-3 rounded-lg cta-button hover:bg-orange-600">
                         Join the Lab
                     </a>
                 </div>


### PR DESCRIPTION
Changed the `href` attribute on the "Join the Lab" button in `oil.html` to a `mailto:` link pointing to `foundation@idea-forge.org`, with a pre-filled subject and body.

---
*PR created automatically by Jules for task [9646208077246843995](https://jules.google.com/task/9646208077246843995) started by @LokiMetaSmith*