### PR TITLE
Add new makerspaces to Maker Passport

### DIFF
--- a/maker-passport-template.html
+++ b/maker-passport-template.html
@@ -431,6 +431,7 @@
 <span>VERIFIED STOP</span>
 </div>
 <h2>ECOSYSTEM OUTPOST: PROJECT 3810</h2>
+<p><span class="bold">ADDRESS:</span> 3810 N Tulsa Ave, Oklahoma City, OK 73112</p>
 <p><span class="bold">VIBE CHECK:</span> Heavy machinery, brilliant startups, and a killer community.</p>
 <br/>
 <p class="bold">KNOWN RESOURCES:</p>
@@ -448,6 +449,7 @@
 <span>VERIFIED STOP</span>
 </div>
 <h2>ECOSYSTEM OUTPOST: THE VERGE OKC</h2>
+<p><span class="bold">ADDRESS:</span> 600 N Robinson Ave 5th Floor, Oklahoma City, OK 73102</p>
 <p><span class="bold">VIBE CHECK:</span> The ultimate collision space for founders, funders, and ecosystem builders.</p>
 <br/>
 <p class="bold">KNOWN RESOURCES:</p>
@@ -465,6 +467,7 @@
 <span>VERIFIED STOP</span>
 </div>
 <h2>ECOSYSTEM OUTPOST: STARSPACE46</h2>
+<p><span class="bold">ADDRESS:</span> 1141 W Sheridan Ave, Oklahoma City, OK 73106</p>
 <p><span class="bold">VIBE CHECK:</span> Oklahoma City's premier hub for developers, tech meetups, and civic hackers.</p>
 <br/>
 <p class="bold">KNOWN RESOURCES:</p>
@@ -473,6 +476,262 @@
 <p>- Late-Night Coding Fuel</p>
 <br/>
 <p><span class="bold">SIDE QUEST:</span> Find the most obscure programming sticker on a laptop.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: BETHANY LIBRARY</h2>
+<p><span class="bold">ADDRESS:</span> 6700 NW 35th Street, Bethany, OK 73008</p>
+<p><span class="bold">VIBE CHECK:</span> A community hub featuring 3D printers and crafting technology.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- 3D Printers<br>- Button Makers<br>- Crafting Supplies</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Design a custom button and print it on the 3D printer.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: FAB LAB TULSA</h2>
+<p><span class="bold">ADDRESS:</span> 501 S Lewis Ave, Tulsa, OK 74104</p>
+<p><span class="bold">VIBE CHECK:</span> Tulsa's premier MIT-chartered Fab Lab with industrial-grade tools.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- CNC Routers<br>- Laser Cutters<br>- Electronics Bench</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Learn to use the CNC router and make a small wooden sign.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: UCO MAKERSPACE</h2>
+<p><span class="bold">ADDRESS:</span> 100 N University Dr, Edmond, OK 73034</p>
+<p><span class="bold">VIBE CHECK:</span> A university space open to students for prototyping and design.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- 3D Printers<br>- VR/AR Equipment<br>- Sewing Machines</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Experience a VR simulation and sketch a physical prototype.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: SMO TINKERING GARAGE</h2>
+<p><span class="bold">ADDRESS:</span> 2020 Remington Pl, Oklahoma City, OK 73111</p>
+<p><span class="bold">VIBE CHECK:</span> A hands-on, family-friendly tinkering space inside the Science Museum.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- Hand Tools<br>- Recycled Materials<br>- Simple Electronics</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Build a structure out of recycled materials that can hold a book.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: PIONEER LIBRARY SYSTEM - NORMAN CENTRAL</h2>
+<p><span class="bold">ADDRESS:</span> 103 W Acres St, Norman, OK 73069</p>
+<p><span class="bold">VIBE CHECK:</span> A central library space equipped for modern digital and physical making.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- Laser Engravers<br>- 3D Printers<br>- A/V Equipment</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Record a short audio story or engrave your name on a token.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: PIONEER LIBRARY SYSTEM - NOBLE</h2>
+<p><span class="bold">ADDRESS:</span> 204 N 5th St, Noble, OK 73068</p>
+<p><span class="bold">VIBE CHECK:</span> A local branch bringing maker tech to the Noble community.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- 3D Printers<br>- Cricut Makers<br>- STEM Kits</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Use the Cricut to cut out a personalized sticker.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: PIONEER LIBRARY SYSTEM - SHAWNEE</h2>
+<p><span class="bold">ADDRESS:</span> 101 N Philadelphia Ave, Shawnee, OK 74801</p>
+<p><span class="bold">VIBE CHECK:</span> Shawnee's hub for creative exploration and digital learning.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- 3D Printers<br>- Robotics Kits<br>- Design Software</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Program a simple robot to navigate a maze.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: PIONEER LIBRARY SYSTEM - SOUTHWEST OKC</h2>
+<p><span class="bold">ADDRESS:</span> 2201 SW 134th St, Oklahoma City, OK 73170</p>
+<p><span class="bold">VIBE CHECK:</span> A bustling community space with tools for creators of all ages.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- 3D Printers<br>- Heat Presses<br>- Sewing Machines</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Learn a new stitch on the sewing machine or design a heat-press graphic.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: PIONEER LIBRARY SYSTEM - MOBILE MAKER LAB</h2>
+<p><span class="bold">ADDRESS:</span> Various Locations</p>
+<p><span class="bold">VIBE CHECK:</span> A traveling maker space bringing tools and knowledge to the people.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- Mobile 3D Printers<br>- Laptops<br>- Hands-on STEM</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Catch the mobile lab at an event and build a simple circuit.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: OU GIBBS COLLEGE MAKER LABS</h2>
+<p><span class="bold">ADDRESS:</span> 830 Van Vleet Oval, Norman, OK 73019</p>
+<p><span class="bold">VIBE CHECK:</span> The heart of student innovation and architecture making at OU.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- High-Res 3D Printing<br>- CNC Routing<br>- Woodworking</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Find an architecture student and ask about their prototype.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: LAWTON PUBLIC LIBRARY</h2>
+<p><span class="bold">ADDRESS:</span> 110 SW 4th St, Lawton, OK 73501</p>
+<p><span class="bold">VIBE CHECK:</span> Empowering southwestern Oklahoma with hands-on learning.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- Cricut Machines<br>- Sublimation Printers<br>- STEM Kits</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Sublimate a design onto a mug or piece of fabric.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: MUSTANG PUBLIC LIBRARY</h2>
+<p><span class="bold">ADDRESS:</span> 1201 N Mustang Rd, Mustang, OK 73064</p>
+<p><span class="bold">VIBE CHECK:</span> A dynamic space offering hands-on activities for the Mustang community.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- 3D Printers<br>- Coding Resources<br>- Crafting Supplies</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Write a basic script in Python or Scratch.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: ALMONTE LIBRARY</h2>
+<p><span class="bold">ADDRESS:</span> 2914 SW 59th St, Oklahoma City, OK 73119</p>
+<p><span class="bold">VIBE CHECK:</span> A neighborhood library fostering creativity and tech literacy.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- 3D Printers<br>- Educational Robots<br>- Art Supplies</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Create a piece of art combining traditional media and 3D printing.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: PIONEER LIBRARY SYSTEM - MOORE</h2>
+<p><span class="bold">ADDRESS:</span> 225 S Howard Ave, Moore, OK 73160</p>
+<p><span class="bold">VIBE CHECK:</span> A community-focused space with tools for fabrication and design.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- Laser Cutters<br>- Sewing Machines<br>- Electronics Kits</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Laser cut a custom coaster or keychain.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: TULSA CITY-COUNTY LIBRARY (CENTRAL)</h2>
+<p><span class="bold">ADDRESS:</span> 400 Civic Center, Tulsa, OK 74103</p>
+<p><span class="bold">VIBE CHECK:</span> A comprehensive maker space in the heart of downtown Tulsa.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- Audio/Video Studios<br>- Laser Cutters<br>- 3D Printers</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Edit a short video clip or manipulate an image in the digital lab.</p>
+<div class="stamp-box">
+<span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
+</div>
+</div><div class="page dot-grid">
+<div class="header-split">
+<span>OKC ECOSYSTEM NODE</span>
+<span>VERIFIED STOP</span>
+</div>
+<h2>ECOSYSTEM OUTPOST: THIRD SPACE STUDIO</h2>
+<p><span class="bold">ADDRESS:</span> 617 W Sheridan Ave, Oklahoma City, OK 73102</p>
+<p><span class="bold">VIBE CHECK:</span> An independent, community-driven arts and maker space.</p>
+<br/>
+<p class="bold">KNOWN RESOURCES:</p>
+<p>- Screen Printing<br>- Fiber Arts<br>- Shared Workspace</p>
+<br/>
+<p><span class="bold">SIDE QUEST:</span> Try your hand at screen printing a simple design.</p>
 <div class="stamp-box">
 <span class="stamp-text">PROOF OF VISIT<br/>(STAMP HERE)</span>
 </div>


### PR DESCRIPTION
Adds 16 new makerspaces to the maker passport template, ensuring a total page count of 24 (a multiple of 4) for booklet printing. Also updates existing makerspaces to include their physical addresses.

---
*PR created automatically by Jules for task [579919995021801615](https://jules.google.com/task/579919995021801615) started by @LokiMetaSmith*